### PR TITLE
Fix test infrastructure for React

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -133,7 +133,7 @@
     "node": ">=6.9.0"
   },
   "scripts": {
-    "lint": "tslint --type-check --project './tsconfig.json' -e 'node_modules/**'",
+    "lint": "tslint --project './tsconfig.json' -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig-aot.json",
     "cleanup": "rimraf <%= BUILD_DIR %>{aot,www}",

--- a/generators/client/templates/angular/webpack/_webpack.test.js
+++ b/generators/client/templates/angular/webpack/_webpack.test.js
@@ -1,5 +1,24 @@
-const path = require('path');
+
+<%#
+ Copyright 2013-2017 the original author or authors from the JHipster project.
+
+    This file is part of the JHipster project, see http://www.jhipster.tech/
+    for more information.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+limitations under the License.
+-%>
 const webpack = require('webpack');
+const path = require('path');
 const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
 const utils = require('./utils.js');

--- a/generators/client/templates/react/_package.json
+++ b/generators/client/templates/react/_package.json
@@ -1,8 +1,27 @@
+<%#
+Copyright 2013-2017 the original author or authors from the JHipster project.
+
+This file is part of the JHipster project, see http://www.jhipster.tech/
+for more information.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-%>
 {
-  "name": "react-client",
+  "name": "<%= dasherizedBaseName %>",
   "version": "0.0.0",
-  "description": "React client app",
+  "description": "Description for <%= baseName %>",
   "private": true,
+  "license": "UNLICENSED",
   "cacheDirectories": [
     "node_modules"
   ],
@@ -30,9 +49,16 @@
     "redux-devtools": "3.4.0",
     "redux-devtools-dock-monitor": "1.1.2",
     "redux-devtools-log-monitor": "1.3.0",
-    "redux-promise-middleware": "4.3.0",
+    "redux-promise-middleware": "4.4.1",
     "redux-thunk": "2.2.0",
-    "uuid": "3.1.0"
+    "uuid": "3.1.0",
+    "chai": "4.1.2",
+    "chai-enzyme": "v1.0.0-beta.0",
+    "core-js": "2.5.1",
+    "enzyme": "3.1.0",
+    "enzyme-adapter-react-16": "1.0.3",
+    "react-test-renderer": "16.0.0",
+    "sinon": "4.0.2"
   },
   "devDependencies": {
     "@types/chai": "4.0.4",
@@ -51,13 +77,10 @@
     "awesome-typescript-loader": "3.3.0",
     "browser-sync": "2.18.13",
     "browser-sync-webpack-plugin": "1.2.0",
-    "chai": "4.1.2",
-    "chai-enzyme": "0.8.0",
+    "chai-as-promised": "7.1.1",
     "copy-webpack-plugin": "4.2.0",
-    "core-js": "2.5.1",
     "cross-env": "5.1.1",
     "css-loader": "0.28.7",
-    "enzyme": "3.1.0",
     "extract-text-webpack-plugin": "3.0.2",
     "file-loader": "1.1.5",
     "html-webpack-plugin": "2.30.1",
@@ -87,11 +110,8 @@
     "protractor": "5.1.2",
     "protractor-jasmine2-screenshot-reporter": "0.4.1",
     <%_ } _%>
-    "react-addons-test-utils": "15.6.2",
-    "react-test-renderer": "16.0.0",
     "redux-mock-store": "1.3.0",
     "rimraf": "2.6.2",
-    "sinon": "4.0.2",
     "source-map-loader": "0.2.3",
     "sourcemap-istanbul-instrumenter-loader": "0.2.0",
     "stripcomment-loader": "0.1.0",
@@ -127,7 +147,7 @@
     "node": ">=6.9.0"
   },
   "scripts": {
-    "lint": "tslint --type-check --project './tsconfig.json' -e 'node_modules/**'",
+    "lint": "tslint --project './tsconfig.json' -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "cleanup": "rimraf <%= BUILD_DIR %>www",
     "start": "<%= clientPackageManager %> run webpack:dev",

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */ // TODO Fix when page is completed
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Button, Form, FormGroup, Label, Input, FormText } from 'reactstrap';
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 
 import { getSession } from '../../../reducers/authentication';
 import { savePassword } from '../../../reducers/account';

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */ // TODO Fix when page is completed
 import * as React from 'react';
-import { Button, Form, FormGroup, Label, Input, FormText } from 'reactstrap';
+import { Button, Form, FormGroup, Label, Input } from 'reactstrap';
 import { connect } from 'react-redux';
 import { locales } from '../../../config/translation';
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Translate } from 'react-jhipster';
-import { Table, Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { Table } from 'reactstrap';
 import * as FaEye from 'react-icons/lib/fa/eye';
 import * as FaRefresh from 'react-icons/lib/fa/refresh';
 import HealthModal from './health-modal';

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */ // TODO Fix when page is completed
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Table, Progress, Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
+import { Table, Progress } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 import * as FaRefresh from 'react-icons/lib/fa/refresh';
 import * as FaEye from 'react-icons/lib/fa/eye';
@@ -163,7 +163,7 @@ export class MetricsPage extends React.Component<any, any> {
     )
 
   render() {
-    const { metrics, isFetching, threadDump } = this.props;
+    const { metrics, isFetching } = this.props;
     const data = metrics || {};
     const { servicesStats, cachesStats } = this.getStats(data);
     return (

--- a/generators/client/templates/react/src/test/javascript/spec/entry.ts
+++ b/generators/client/templates/react/src/test/javascript/spec/entry.ts
@@ -2,6 +2,10 @@ import 'core-js';
 import * as sinon from 'sinon';
 import * as chai from 'chai';
 import * as chaiEnzyme from 'chai-enzyme';
+import { configure } from 'enzyme';
+import * as Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
 
 chai.use(chaiEnzyme());
 

--- a/generators/client/templates/react/webpack/webpack.test.js
+++ b/generators/client/templates/react/webpack/webpack.test.js
@@ -56,7 +56,7 @@ module.exports = {
           loader: 'awesome-typescript-loader',
           options: {
             useCache: true,
-            ignoreDiagnostics: [2307] // due to a weird false error fro json files
+            ignoreDiagnostics: [2307] // due to a weird false error from json files
           }
         }],
         include: [path.resolve('./src/main/webapp/app'), path.resolve('./src/test/javascript')],


### PR DESCRIPTION
Before these changes, tests were failing to compile and dependencies were not found. Moving many of the test dependencies to `dependencies` instead of `devDependencies` solves the problem, but it doesn't seem like a good solution. Without it, the following errors occur:

```
ERROR: .../spec/app/config/notification-middleware.spec.ts[1, 24]: Module 'chai' is not listed as dependency in package.json
ERROR: .../spec/app/shared/layout/header.spec.tsx[2, 25]: Module 'enzyme' is not listed as dependency in package.json
ERROR: .../spec/app/shared/layout/header.spec.tsx[3, 24]: Module 'chai' is not listed as dependency in package.json
ERROR: .../spec/app/shared/layout/header.spec.tsx[4, 24]: Module 'sinon' is not listed as dependency in package.json
ERROR: .../spec/app/shared/util/storage-util.spec.ts[1, 24]: Module 'chai' is not listed as dependency in package.json
ERROR: .../spec/entry.ts[1, 8]: Module 'core-js' is not listed as dependency in package.json
ERROR: .../spec/entry.ts[2, 24]: Module 'sinon' is not listed as dependency in package.json
ERROR: .../spec/entry.ts[3, 23]: Module 'chai' is not listed as dependency in package.json
ERROR: .../spec/entry.ts[4, 29]: Module 'chai-enzyme' is not listed as dependency in package.json
```

Maybe this is caused by a webpack configuration issue?

The good news is everything works after these changes!

![image](https://user-images.githubusercontent.com/17892/32310792-844f556a-bf5a-11e7-8b7f-b305825a8511.png)
