### PR TITLE
Fix uaa-server generation regression

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -535,7 +535,7 @@ const serverFiles = {
     ],
     serverMicroservice: [
         {
-            condition: generator => generator.applicationType === 'microservice' || generator.authenticationType === 'uaa',
+            condition: generator => generator.applicationType === 'microservice' || (generator.authenticationType === 'uaa' && generator.applicationType !== 'uaa'),
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 { file: 'package/config/MicroserviceSecurityConfiguration.java', renameTo: generator => `${generator.javaDir}config/SecurityConfiguration.java` }


### PR DESCRIPTION
The condition I proposed on the generation of package/config/MicroserviceSecurityConfiguration.java.ejs was broken : 
This file is needed for gateway and microservice but not for the uaa server

It is the cause of this failure : https://travis-ci.org/jhipster/generator-jhipster/jobs/382435969
